### PR TITLE
#35 Fix: Move resource creation from 'BeginProcessing' to 'ProcessRec…

### DIFF
--- a/AngleParse/SelectHtmlElement.cs
+++ b/AngleParse/SelectHtmlElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Management.Automation;
 using AngleParse.Resource;
 using AngleParse.Selector;
@@ -13,29 +14,35 @@ public class SelectHtmlElement : PSCmdlet
         Mandatory = true,
         Position = 0,
         HelpMessage = "Selector to select and process data in the content.")]
-    public object[] Selector { get; set; } = null!;
+    public object[]? Selector { get; set; }
 
     [Parameter(
         Position = 1,
         ValueFromPipeline = true,
         ValueFromPipelineByPropertyName = true,
         HelpMessage = "HTML content.")]
-    public string Content { get; set; } = null!;
+    public string? Content { get; set; }
 
     private ISelector<ElementResource, ObjectResource> Pipeline { get; set; } = null!;
-    private ElementResource ElementResource { get; set; } = null!;
 
     protected override void BeginProcessing()
     {
+        if (Selector is null || Selector.Length == 0)
+            throw new ArgumentNullException(nameof(Selector), "Selector cannot be null or empty.");
         Pipeline = SelectorFactory.CreatePipeline(Selector);
-        ElementResource = ElementResource.CreateAsync(Content).GetAwaiter().GetResult();
     }
 
     protected override void ProcessRecord()
     {
+        if (Content is null)
+            throw new ArgumentNullException(nameof(Content), "Content cannot be null.");
+        var elementResource = ElementResource
+            .CreateAsync(Content)
+            .GetAwaiter()
+            .GetResult();
         WriteObject(
             Pipeline
-                .Select(ElementResource)
+                .Select(elementResource)
                 .Select(r => new PSObject(r.Object))
                 .ToArray(),
             true


### PR DESCRIPTION
…ord'

Resolved a bug by relocating the resource creation process from the 'BeginProcessing' method to the 'ProcessRecord' method to ensure proper handling during execution.