### PR TITLE
#49 Override error action to continue in scriptblock test case

### DIFF
--- a/AngleParse.PesterTests/Select-HtmlContent.Tests.ps1
+++ b/AngleParse.PesterTests/Select-HtmlContent.Tests.ps1
@@ -322,7 +322,8 @@ Describe 'Select-HtmlContent' {
         }
         It 'outputs the result even if the Write-Error is called in the scriptblock' {
             $result = Get-Asset 'full-attribute.html' | Select-HtmlContent {
-                Write-Error -Message "Error in scriptblock" 2> $null
+                # Override the error action to continue which is the default in PowerShell.
+                Write-Error -Message "Error in scriptblock" -ErrorAction 'Continue' 2> $null
                 return 1
             }
             $result | should -be 1


### PR DESCRIPTION
The purpose of this change is to address test failures in the CI environment. The failures occur because the default error action in the CI environment is modified, causing entire CI workflows stops.